### PR TITLE
New current direction retireval code and attribute writing

### DIFF
--- a/seastar/oscar/level1.py
+++ b/seastar/oscar/level1.py
@@ -256,12 +256,9 @@ def compute_incidence_angle_from_simple_geometry(ds):
     X, Y = np.meshgrid(ds.CrossRange, ds.GroundRange, indexing='ij')
     if 'SquintImage' in ds:
         ds['IncidenceAngleImage'] = np.degrees(
-            np.arctan(
-                np.abs(ds.SquintImage)
-                * Y
-                / ds.OrbHeightImage
-                )
+            Y / (np.cos(ds.SquintImage) / ds.OrbHeightImage)
             )
+
     elif 'SquintImage' not in ds:
         warnings.warn(
             "WARNING: No computed antenna squint present,"

--- a/seastar/retrieval/level2.py
+++ b/seastar/retrieval/level2.py
@@ -68,8 +68,8 @@ def compute_current_magnitude_and_direction(level1, level2):
         / np.sin(np.radians(antenna_angle))
     level2.CurrentMagnitude.attrs['long_name'] =\
         'Total surface current magnitude for each pixel in the image'
-    level2.CurrentMagnitude.attrs['units'] = '[m/s]'
 
+    level2.CurrentMagnitude.attrs['units'] = '[m/s]'
     u_1 = level1.sel(Antenna='Fore').RadialSurfaceCurrent\
         * np.cos(np.radians(level1.sel(Antenna='Fore').AntennaAzimuthImage))
     v_1 = level1.sel(Antenna='Fore').RadialSurfaceCurrent\
@@ -81,16 +81,16 @@ def compute_current_magnitude_and_direction(level1, level2):
 
     direction = np.degrees(np.arctan2((u_1 + u_2), (v_1 + v_2)))
     ind_pos = direction < 0
-    #direction[direction < 0] = 180 + (180 - np.abs(direction))
+
     direction_corrected = xr.where(ind_pos,
                                    180 + (180 - np.abs(direction)),
                                    direction
                                    )
-    direction_corrected = np.mod(direction_corrected - 90, 360)
+
     level2['CurrentDirection'] = direction_corrected
     level2.CurrentDirection.attrs['long_name'] =\
         'Total surface current direction (oceanographic convention)'\
-        'for each pixel in the image'
+        ' for each pixel in the image'
     level2.CurrentDirection.attrs['units'] = '[degrees]'
 
     return level2

--- a/seastar/retrieval/level2.py
+++ b/seastar/retrieval/level2.py
@@ -93,6 +93,10 @@ def compute_current_magnitude_and_direction(level1, level2):
         ' for each pixel in the image'
     level2.CurrentDirection.attrs['units'] = '[degrees]'
 
+    level2['CurrentMagnitude'] = level2.CurrentMagnitude.assign_coords(
+        coords={'longitude': level2.longitude, 'latitude': level2.latitude})
+    level2['CurrentDirection'] = level2.CurrentDirection.assign_coords(
+        coords={'longitude': level2.longitude, 'latitude': level2.latitude})
     return level2
 
 

--- a/seastar/retrieval/level2.py
+++ b/seastar/retrieval/level2.py
@@ -35,6 +35,30 @@ def compute_current_magnitude_and_direction(level1, level2):
         Surface current direction (degrees N) in oceanographic convention
 
     """
+    #antenna_angle = np.mod(level1.sel(Antenna='Fore').AntennaAzimuthImage -
+    #                       level1.sel(Antenna='Aft').AntennaAzimuthImage,
+    #                       360)
+    #level2['CurrentMagnitude'] = np.sqrt(
+    #    level1.sel(Antenna='Fore').RadialSurfaceCurrent ** 2
+    #    + level1.sel(Antenna='Aft').RadialSurfaceCurrent ** 2)\
+    #    / np.sin(np.radians(antenna_angle))
+
+    #ind_pos = (level1.sel(Antenna='Fore').RadialSurfaceCurrent >
+    #           level1.sel(Antenna='Aft').RadialSurfaceCurrent) *\
+    #    np.cos(np.radians(antenna_angle))
+    # temporary_direction = xr.DataArray(np.empty(ind_pos.shape),
+    #                                    coords=[level2.CrossRange,
+    #                                            level2.GroundRange],
+    #                                    dims=('CrossRange', 'GroundRange'))
+    #temporary_direction = xr.where(ind_pos,
+    #                               np.degrees(np.arccos(
+    #                                   level1.sel(Antenna='Fore').RadialSurfaceCurrent /
+    #                                   level2.CurrentMagnitude)),
+    #                               - np.degrees(np.arccos(
+    #                                   level1.sel(Antenna='Fore').RadialSurfaceCurrent /
+    #                                   level2.CurrentMagnitude)))
+    #level2['CurrentDirection'] = np.mod(level1.sel(Antenna='Fore').AntennaAzimuthImage
+    #                                    + (-temporary_direction), 360)
     antenna_angle = np.mod(level1.sel(Antenna='Fore').AntennaAzimuthImage -
                            level1.sel(Antenna='Aft').AntennaAzimuthImage,
                            360)
@@ -42,24 +66,32 @@ def compute_current_magnitude_and_direction(level1, level2):
         level1.sel(Antenna='Fore').RadialSurfaceCurrent ** 2
         + level1.sel(Antenna='Aft').RadialSurfaceCurrent ** 2)\
         / np.sin(np.radians(antenna_angle))
+    level2.CurrentMagnitude.attrs['long_name'] =\
+        'Total surface current magnitude for each pixel in the image'
+    level2.CurrentMagnitude.attrs['units'] = '[m/s]'
 
-    ind_pos = (level1.sel(Antenna='Fore').RadialSurfaceCurrent >
-               level1.sel(Antenna='Aft').RadialSurfaceCurrent) *\
-        np.cos(np.radians(antenna_angle))
-    # temporary_direction = xr.DataArray(np.empty(ind_pos.shape),
-    #                                    coords=[level2.CrossRange,
-    #                                            level2.GroundRange],
-    #                                    dims=('CrossRange', 'GroundRange'))
-    temporary_direction = xr.where(ind_pos,
-                                   np.degrees(np.arccos(
-                                       level1.sel(Antenna='Fore').RadialSurfaceCurrent /
-                                       level2.CurrentMagnitude)),
-                                   - np.degrees(np.arccos(
-                                       level1.sel(Antenna='Fore').RadialSurfaceCurrent /
-                                       level2.CurrentMagnitude)))
-    level2['CurrentDirection'] = np.mod(level1.sel(Antenna='Fore').AntennaAzimuthImage
-                                        + (-temporary_direction), 360)
-    level2 = level2.drop('Antenna')
+    u_1 = level1.sel(Antenna='Fore').RadialSurfaceCurrent\
+        * np.cos(np.radians(level1.sel(Antenna='Fore').AntennaAzimuthImage))
+    v_1 = level1.sel(Antenna='Fore').RadialSurfaceCurrent\
+        * np.sin(np.radians(level1.sel(Antenna='Fore').AntennaAzimuthImage))
+    u_2 = level1.sel(Antenna='Aft').RadialSurfaceCurrent\
+        * np.cos(np.radians(level1.sel(Antenna='Aft').AntennaAzimuthImage))
+    v_2 = level1.sel(Antenna='Aft').RadialSurfaceCurrent\
+        * np.sin(np.radians(level1.sel(Antenna='Aft').AntennaAzimuthImage))
+
+    direction = np.degrees(np.arctan2((u_1 + u_2), (v_1 + v_2)))
+    ind_pos = direction < 0
+    #direction[direction < 0] = 180 + (180 - np.abs(direction))
+    direction_corrected = xr.where(ind_pos,
+                                   180 + (180 - np.abs(direction)),
+                                   direction
+                                   )
+    direction_corrected = np.mod(direction_corrected - 90, 360)
+    level2['CurrentDirection'] = direction_corrected
+    level2.CurrentDirection.attrs['long_name'] =\
+        'Total surface current direction (oceanographic convention)'\
+        'for each pixel in the image'
+    level2.CurrentDirection.attrs['units'] = '[degrees]'
 
     return level2
 


### PR DESCRIPTION
New current retrieval code to address issue #186 . New code uses slightly more transparent trig and atan rather than acos, effectively just calculating vector components for each beam, then finding the inverse tangent of their combination. Tested at first on the X-band current vectors to re-create the directions Ruben sent us in his .kmz file.

The results didn't look good at first but there was an additional bug (on my end) with an erroneous wind direction. With this corrected the WASV is better and the comparison is now pretty good:
![image](https://user-images.githubusercontent.com/107252303/200892291-fa731cc0-5950-43c4-91fe-219da4335109.png)
![image](https://user-images.githubusercontent.com/107252303/200892387-15cc2286-be27-4e03-9c09-34ff08ed6425.png)
