### PR TITLE
Error in Aft beam direction convention fix

### DIFF
--- a/seastar/oscar/level1.py
+++ b/seastar/oscar/level1.py
@@ -648,6 +648,14 @@ def compute_radial_surface_current(level1, aux, gmf='mouche12'):
                 - dswasv.sel(Antenna=a)
                 for a in list(level1.Antenna.data)
                 ]
+    warnings.warn(
+        "WARNING: Applying direction convention correction on the Aft beam,"
+        "Be aware this may be an obsolete correction in the future and will"
+        "lead to an error in retrieved current direction."
+    )
+    rsv_list[list(level1.Antenna.data).index('Aft')] = \
+        -level1.RadialSurfaceVelocity.sel(Antenna='Aft')\
+        - dswasv.sel(Antenna='Aft')
     level1['RadialSurfaceCurrent'] = xr.concat(rsv_list,
                                                'Antenna',
                                                join='outer')

--- a/seastar/oscar/level1.py
+++ b/seastar/oscar/level1.py
@@ -648,14 +648,14 @@ def compute_radial_surface_current(level1, aux, gmf='mouche12'):
                 - dswasv.sel(Antenna=a)
                 for a in list(level1.Antenna.data)
                 ]
-    warnings.warn(
-        "WARNING: Applying direction convention correction on the Aft beam,"
-        "Be aware this may be an obsolete correction in the future and will"
-        "lead to an error in retrieved current direction."
-    )
-    rsv_list[list(level1.Antenna.data).index('Aft')] = \
-        -level1.RadialSurfaceVelocity.sel(Antenna='Aft')\
-        - dswasv.sel(Antenna='Aft')
+#    warnings.warn(
+#        "WARNING: Applying direction convention correction on the Aft beam,"
+#        "Be aware this may be an obsolete correction in the future and will"
+#        "lead to an error in retrieved current direction."
+#    )
+#    rsv_list[list(level1.Antenna.data).index('Aft')] = \
+#        -level1.RadialSurfaceVelocity.sel(Antenna='Aft')\
+#        - dswasv.sel(Antenna='Aft')
     level1['RadialSurfaceCurrent'] = xr.concat(rsv_list,
                                                'Antenna',
                                                join='outer')

--- a/seastar/retrieval/level2.py
+++ b/seastar/retrieval/level2.py
@@ -84,7 +84,7 @@ def compute_current_magnitude_and_direction(level1, level2):
     direction_corrected = np.mod(-xr.where(ind_pos,
                                  180 + (180 - np.abs(direction)),
                                  direction
-                                 ),
+                                 ) + 90,
                                  360)
 
     level2['CurrentDirection'] = direction_corrected


### PR DESCRIPTION
Changing the direction convention of the Aft beam to fix the error in retrieved currents. Additionally re-inserting the 90 degree addition to the retrieved current
direction as this had been erroneously removed in the past.