### PR TITLE
New, faster land mask computation

### DIFF
--- a/seastar/oscar/seastarex_DAR_config.ini
+++ b/seastar/oscar/seastarex_DAR_config.ini
@@ -1,0 +1,13 @@
+[20220522]
+Track_L1 = 0
+Track_1a = 1
+Track_2a = 2
+Track_1b = 3
+Track_11 = 4
+Track_12 = 5
+Track_13 = 6
+Track_14 = 7
+Track_15 = 8
+Track_16 = 9
+Track_17 = 10
+Track_18 = 11

--- a/seastar/utils/readers.py
+++ b/seastar/utils/readers.py
@@ -40,6 +40,44 @@ def _set_file_paths():
     return local_paths
 
 
+def _read_DAR_config(date):
+    """
+    Read DAR track name config.
+
+    Reads the seastarex_DAR_config.ini file containing names for aquisition
+    as a dict with keys equalling track names and values equalling the file
+    list number for loading.
+
+    Parameters
+    ----------
+    date : ``str``, ``int``
+        Date of aquisition in the form YYYYMMDD
+
+    Raises
+    ------
+    Exception
+        DESCRIPTION.
+
+    Returns
+    -------
+    DAR_tracks : ``dict``
+        Dict of {track names : file number}. File numbers of type ``int``.
+        Track names capitalised.
+
+    """
+    if type(date) is not str:
+        date = str(date)
+    config = ConfigParser()
+    config_path = os.path.join('seastar', 'oscar', 'seastarex_DAR_config.ini')
+    config.read(config_path)
+    if date not in config.sections():
+        raise Exception('Date not present in seastarex_DAR_config.ini.'
+                        'Please check config file')
+    DAR_tracks = dict(config.items(date))
+    DAR_tracks = {str.capitalize(k): int(v) for k, v in DAR_tracks.items()}
+    return DAR_tracks
+
+
 def _readConfig(config_file_path):
     """Reads the configuration ini file.
 

--- a/seastar/utils/tools.py
+++ b/seastar/utils/tools.py
@@ -512,38 +512,45 @@ class dotdict(dict):
     __delattr__ = dict.__delitem__
 
 
-def compute_land_mask_from_GSHHS(ds, erosion=False, boundary=None,
-                                 erode_scale=3, coastline_selection=0):
+def compute_land_mask_from_GSHHS(da, boundary=None, skip=1/1000, erosion=False,
+                                      erode_scale = 3, coastline_selection=0,):
     """
-    Compute boolean land mask from GSHHS global coastline.
+    Compute land mask.
 
     Computes a boolean mask with size, coords and dims corresponding to a
-    supplied xarray.Dataset, with mask values = True where the point lies
+    supplied xarray.DataArray, with mask values = True where the point lies
     within the coastline from the GSHHS global coastline dataset.
 
     Parameters
     ----------
-    ds : ``xarray.Dataset``
-        Dataset containing `longitude` and `latitude` coordinates as well as
+    da : ``xarray.DataArray``
+        xarray.DataArray to compute the land mask for. Must contain
+        `longitude` and `latitude` coordinates as well as
         coords and dims to align the new `mask` to.
-    erosion : ``bool``, optional
-        Boolean switch to trigger binary erosion of the resulting `mask`.
-        The default is False.
     boundary : ``list``, optional
         Optional boundary to check for the presence of coastlines in the GSHHS
         dataset. Supply `boundary` in the form:
         `[min(long), max(long), min(lat), max(lat)]`.
         The default boundary will be set to the minimum and maximum extent of
-        the `longitude` and `latitude` data present in the coords of `ds`.
+        the `longitude` and `latitude` data present in the coords of `da`.
+    skip : ``float``, optional
+        Speed-up factor in degrees longitude / latitude. The default is 1/1000.
+        Lower than 1/250 resolution will result in a coarsening of the computed
+        `mask`.
+    erosion : ``bool``, optional
+        Boolean switch to trigger binary erosion of the resulting `mask`.
+        The default is False.
     erode_scale : ``int``, ``float``, optional
         Scale for the array-like structure used for optional binary erosion.
         When default is used but `erosion=True` then a
         `erode_scale` of 3 is assumed.
     coastline_selection : ``int``, ``list``, optional
-        Manual choice of which identified coastlines within `boundary` are used
-        in the generation of the `mask`. Choice is a key or list of keys of
-        type ``int``. The default is 0. The default behaviour is the first
-        identified coastline within `boundary` is used to generate the `mask`.
+        Manual choice of which identified coastlines present within the 
+        `boundary` are used in the generation of the `mask`. 
+        Choice is a key or list of keys of type ``int``. The default is 0. 
+        The default behaviour is the first identified coastline within 
+        `boundary` is used to generate the `mask`, corresponding to the largest
+        coastline within the `boundary` by internal area.
 
     Raises
     ------
@@ -556,21 +563,16 @@ def compute_land_mask_from_GSHHS(ds, erosion=False, boundary=None,
     -------
     mask : ``bool``, ``array``, ``xr.DataArray``
         An xr.DataArray containing an array-like boolean mask of land pixels.
-    coast_polygons : ``dict`` of `shapely Polygons`
-        A dict of all identified coastlines within the supplied or default
-        `boundary`, with keys of values for `coastline_selection` and values
-        of type ``shapely.polygon.Polygon``
-
     """
-
-    if 'longitude' not in ds.coords or 'latitude' not in ds.coords:
+    if 'longitude' not in da.coords or 'latitude' not in da.coords:
         raise Exception('longitude and latitude missing from input dataset')
     if not boundary:
-        boundary = [np.min(ds.longitude.data),
-                    np.max(ds.longitude.data),
-                    np.min(ds.latitude.data),
-                    np.max(ds.latitude.data)]
-
+        boundary = [np.min(da.longitude.data),
+                    np.max(da.longitude.data),
+                    np.min(da.latitude.data),
+                    np.max(da.latitude.data)]
+    longitude, latitude = np.meshgrid(np.arange(boundary[0], boundary[1], skip),
+                                 np.arange(boundary[2], boundary[3], skip))
     if erosion:
         erode_scale = int(np.round(erode_scale))
         erode_structure = np.full((erode_scale, erode_scale), True)
@@ -578,22 +580,21 @@ def compute_land_mask_from_GSHHS(ds, erosion=False, boundary=None,
     print('Scanning GSHHS dataset for coastlines within boundary...')
     coast = cfeature.GSHHSFeature(scale='full')\
         .intersecting_geometries(boundary)
-
     for k, polygon in enumerate(coast):
         coast_polygons[k] = polygon
     if type(coastline_selection) is int:
         coastline_selection = [coastline_selection]
     if np.max(coastline_selection) > k:
         raise Exception('Selected coastline(s)',
-                        coastline_selection,
-                        ' different to coastlines identified within boundary ',
-                        list(coast_polygons.keys()),
-                        '. Please try a different coastline_selection (default=0)'
-                        )
-
+                       coastline_selection,
+                       ' different to coastlines identified within boundary ',
+                       list(coast_polygons.keys()),
+                       '. Please try a different coastline_selection (default=0)'
+                       )
     coast_polygons = {key: coast_polygons[key]
-                      for key in coastline_selection}
-    m, n = ds.longitude.shape
+                     for key in coastline_selection}
+
+    m, n = longitude.shape
     mask = np.full((m, n), False)
     count = 0
     print('Performing search...')
@@ -602,16 +603,28 @@ def compute_land_mask_from_GSHHS(ds, erosion=False, boundary=None,
             count = count + 1
             if not int(np.mod(count, ((m*n) / 10))):
                 print(int((count / (m*n)) * 100), '% complete')
-
             for k in coast_polygons.keys():
                 mask[i, j] = mask[i, j] or\
-                    Point(ds.longitude.data[i, j], ds.latitude.data[i, j])\
-                    .within(coast_polygons[k])
+                   Point(longitude.data[i, j], latitude.data[i, j])\
+                   .within(coast_polygons[k])
     print('...done')
     if erosion:
         mask = erode(mask, structure=erode_structure)
-    mask = xr.DataArray(data=mask,
-                        coords=ds.latitude.coords,
-                        dims=ds.latitude.dims)
+    mask = xr.DataArray(data=mask.astype(int))
+    mask = mask.assign_coords(longitude=(['dim_0', 'dim_1'], longitude),
+                   latitude=(['dim_0', 'dim_1'], latitude),
+                   )
 
-    return mask, coast_polygons
+    new_data = interpolate.griddata(
+                            points=(np.ravel(longitude),
+                                    np.ravel(latitude)),
+                            values=(np.ravel(mask)),
+                            xi=(da.longitude.values,
+                                da.latitude.values),
+                            method='nearest'
+                            )
+    mask = xr.DataArray(
+                        data=new_data,
+                        dims=da.dims,
+                        coords=da.coords)
+    return mask


### PR DESCRIPTION
Takes a DataArray as input - must have `latitude` and `longitude` coords

Should work out of the box - use it like:
`mask = ss.utils.tools.compute_land_mask_from_GSHHS(ds_L1b[track].Interferogram.sel(Antenna='Mid'), skip=1/1000)`

Note that it might not like the Antenna dimension so it has to be selected out on input
