### PR TITLE
Add IntensityAvgMaster field output for Oscar/level1 even when there is no Slave

### DIFF
--- a/seastar/oscar/level1.py
+++ b/seastar/oscar/level1.py
@@ -309,6 +309,18 @@ def compute_multilooking_Master_Slave(ds, window=3,
             'Interferogram between master/slave antenna pair.'
     ds_out.Interferogram.attrs['long_name'] = 'Interferogram'
     ds_out.Interferogram.attrs['units'] = 'rad'
+
+    ds_out['IntensityAvgMaster'] = np.abs(
+        (ds.SigmaSLCMaster ** 2) \
+            .rolling({ds.SigmaSLCMaster.dims[1]: window}).mean() \
+            .rolling({ds.SigmaSLCMaster.dims[0]: window}).mean()
+    )
+    ds_out.IntensityAvgMaster.attrs['long_name'] = \
+        'Intensity Master'
+    ds_out.Intensity.attrs['description'] = \
+        'Average absolute single look complex image intensity for Master SLC (|M^2|)'
+    ds_out.IntensityAvgMaster.attrs['units'] = ''
+
     if 'SigmaSLCSlave' in ds.data_vars:
         ds_out['IntensityAvgSlave'] = np.abs(
             (ds.SigmaSLCSlave ** 2)\
@@ -332,16 +344,6 @@ def compute_multilooking_Master_Slave(ds, window=3,
         'Coherence between master/slave antenna pair'
     ds_out.Coherence.attrs['units'] = ''
 
-    ds_out['IntensityAvgMaster'] = np.abs(
-        (ds.SigmaSLCMaster ** 2)\
-            .rolling({ds.SigmaSLCMaster.dims[1]: window}).mean()\
-            .rolling({ds.SigmaSLCMaster.dims[0]: window}).mean()
-    )
-    ds_out.IntensityAvgMaster.attrs['long_name'] = \
-        'Intensity Master'
-    ds_out.Intensity.attrs['description'] = \
-        'Average absolute single look complex image intensity for Master SLC (|M^2|)'
-    ds_out.IntensityAvgMaster.attrs['units'] = ''
 
     return ds_out[list(vars_to_send)]
 

--- a/seastar/oscar/level1.py
+++ b/seastar/oscar/level1.py
@@ -293,10 +293,9 @@ def compute_multilooking_Master_Slave(ds, window=3,
     ds_out['Intensity'] = np.abs(ds_out.IntensityAvgComplexMasterSlave)
     ds_out.Intensity.attrs['long_name'] = 'SLC Intensity'
     ds_out.Intensity.attrs['description'] =\
-        'Absolute single look complex image intensity'
+        'Average absolute single look complex image intensity (|M.S^*| with ^* complex conjugate, if S missing => |M^2|)'
     ds_out.Intensity.attrs['units'] = ''
     if 'SigmaSLCSlave' not in ds.data_vars:
-
         ds_out['Interferogram'] = xr.DataArray(data=np.NaN)
         ds_out.Interferogram.attrs['description'] =\
             'Interferogram between master/slave antenna pair.'\
@@ -311,31 +310,38 @@ def compute_multilooking_Master_Slave(ds, window=3,
     ds_out.Interferogram.attrs['long_name'] = 'Interferogram'
     ds_out.Interferogram.attrs['units'] = 'rad'
     if 'SigmaSLCSlave' in ds.data_vars:
-        ds_out['IntensityAvgMaster'] = (np.abs(ds.SigmaSLCMaster) ** 2)\
-            .rolling({ds.SigmaSLCMaster.dims[1]: window}).mean()\
-            .rolling({ds.SigmaSLCMaster.dims[0]: window}).mean()
-        ds_out['IntensityAvgSlave'] = (np.abs(ds.SigmaSLCSlave) ** 2)\
-            .rolling({ds.SigmaSLCSlave.dims[1]: window}).mean()\
-            .rolling({ds.SigmaSLCSlave.dims[0]: window}).mean()
+        ds_out['IntensityAvgSlave'] = np.abs(
+            (ds.SigmaSLCSlave ** 2)\
+                .rolling({ds.SigmaSLCSlave.dims[1]: window}).mean()\
+                .rolling({ds.SigmaSLCSlave.dims[0]: window}).mean()
+        )
         ds_out['Coherence'] =\
             ds_out.Intensity / np.sqrt(ds_out.IntensityAvgMaster
                                        * ds_out.IntensityAvgSlave)
     else:
-        ds_out['IntensityAvgMaster'] = xr.DataArray(data=np.NaN)
+        # ds_out['IntensityAvgMaster'] = xr.DataArray(data=np.NaN)
         ds_out['IntensityAvgSlave'] = xr.DataArray(data=np.NaN)
         ds_out['Coherence'] = xr.DataArray(data=np.NaN)
 
+    ds_out.IntensityAvgSlave.attrs['long_name'] = \
+        'Intensity Slave'
+    ds_out.IntensityAvgSlave.attrs['units'] = ''
     ds_out.Coherence.attrs['long_name'] = \
         'Coherence'
     ds_out.Coherence.attrs['description'] = \
         'Coherence between master/slave antenna pair'
     ds_out.Coherence.attrs['units'] = ''
+
+    ds_out['IntensityAvgMaster'] = np.abs(
+        (ds.SigmaSLCMaster ** 2)\
+            .rolling({ds.SigmaSLCMaster.dims[1]: window}).mean()\
+            .rolling({ds.SigmaSLCMaster.dims[0]: window}).mean()
+    )
     ds_out.IntensityAvgMaster.attrs['long_name'] = \
         'Intensity Master'
+    ds_out.Intensity.attrs['description'] = \
+        'Average absolute single look complex image intensity for Master SLC (|M^2|)'
     ds_out.IntensityAvgMaster.attrs['units'] = ''
-    ds_out.IntensityAvgSlave.attrs['long_name'] = \
-        'Intensity Slave'
-    ds_out.IntensityAvgSlave.attrs['units'] = ''
 
     return ds_out[list(vars_to_send)]
 


### PR DESCRIPTION
in "oscar/level1/compute_multilooking_Master_Slave", modification on IntensityAvgMaster to have this field compute when there is a Slave field (case before) or not.

In the typical SeaSTAR/Ascat geometry with ATI on squinted beams and standard SAR on mid beam, the IntensityAvgMaster will now be available for fore/aft and mid. For the mid beam, Intensity==IntensityAvgMaster